### PR TITLE
fix(cert/proxy): 证书安装失败不再静默，代理端口占用不再「假启动」(Fixes #6, #7)

### DIFF
--- a/src-python/device_proxy.py
+++ b/src-python/device_proxy.py
@@ -313,7 +313,14 @@ def log(*a):
     ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     line = f"[{ts}] " + " ".join(str(x) for x in a)
     with _log_lock:
-        print(line, flush=True)
+        # print 必须同样容错：父进程（Rust 侧）退出后本进程可能成为孤儿，
+        # 其 stdout 管道断开会让 print(..., flush=True) 抛 OSError。
+        # 一旦抛出，调用方（如 handle_client）的线程会被直接杀死，
+        # 表现为客户端连接被静默掐断、且日志里查不到任何线索。
+        try:
+            print(line, flush=True)
+        except Exception:
+            pass
         try:
             _logf.write(line + "\n")
         except Exception:
@@ -1794,8 +1801,11 @@ def handle_client(conn, addr):
                 tunnel_raw(conn, host, port)
                 return
             matched = next((d for d in TARGET_DOMAINS if host == d or host.endswith("." + d)), None)
-            log(f"CONNECT {host}:{port}  [TRAE/MITM] 匹配域名: {matched}")
+            # 先回 200 再记日志：与 tunnel_raw() 保持一致。
+            # 若反过来（先 log 后 sendall），日志异常会先把线程打死，
+            # 客户端永远等不到 200 —— 表现为「目标域名全部打不开且日志无任何记录」。
             conn.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            log(f"CONNECT {host}:{port}  [TRAE/MITM] 匹配域名: {matched}")
             # TRAE 域名：MITM 解密以捕获 JWT
             cpath, kpath = leaf_cert(host)
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -1862,8 +1872,16 @@ def main():
         load_accounts()  # 预热 accounts 缓存
         sync_account_devices()  # 升级历史假占位符设备标识
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    srv.bind((LISTEN_HOST, LISTEN_PORT))
+    # 不设 SO_REUSEADDR：Windows 上它允许多个套接字绑定同一 addr:port 且不报错，
+    # 导致上一次泄漏的代理进程仍在接客、本次却「启动成功」，
+    # 而新实例收不到任何连接（表现为目标域名全部打不开、日志无记录）。
+    # 去掉后端口被占用时 bind() 会直接报 WSAEADDRINUSE，便于上层暴露真实错误。
+    try:
+        srv.bind((LISTEN_HOST, LISTEN_PORT))
+    except OSError as e:
+        log(f"[fatal] 端口 {LISTEN_HOST}:{LISTEN_PORT} 绑定失败（{e}）。"
+            f"通常由上一次未退出的代理进程占用，请结束后重试。")
+        return 2
     srv.listen(128)
     log(f"代理已启动: {LISTEN_HOST}:{LISTEN_PORT}  (TRAE 多域 MITM 拦截 + JWT 自动捕获)")
     log("监听 TRAE 域名: " + ", ".join("*." + d for d in TARGET_DOMAINS))

--- a/src-tauri/src/commands/cert.rs
+++ b/src-tauri/src/commands/cert.rs
@@ -26,23 +26,60 @@ pub fn cert_status(_app: AppHandle, _state: State<AppState>) -> CertStatus {
     CertStatus { installed }
 }
 
+/// 生成 CA 证书（data_dir/certs/ca.cer），失败时返回真实原因。
+///
+/// 关键：必须捕获 stdout/stderr 与退出码。此前 `let _ = ...wait()` + `capture=false`
+/// 会把子进程的真实报错（典型如 `ModuleNotFoundError: No module named 'cryptography'`）
+/// 全部丢弃，上层只能给出「CA 证书生成失败」这种无法定位的文案，用户表现为
+/// 「点击安装证书后毫无反应」。这里取 stderr 末 5 行回传，并对「缺 Python 依赖」
+/// 这一最常见根因补充可执行的修复提示。
+fn gen_ca(state: &AppState) -> Result<(), String> {
+    let out = spawn_script(state, "device_proxy.py", &["--gen-ca".to_string()], true)?
+        .wait_with_output()
+        .map_err(|e| format!("生成 CA 证书失败（等待进程结束出错）: {e}"))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    // 取 stderr 末 5 行：traceback 的有效信息在末尾，且避免刷屏
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let mut tail: Vec<&str> = stderr.lines().rev().take(5).collect();
+    tail.reverse();
+    let detail = tail.join("\n");
+    let detail = if detail.trim().is_empty() {
+        format!("子脚本退出码 {:?}", out.status.code())
+    } else {
+        detail
+    };
+    // 最常见根因：安装包未随附 Python 运行时与依赖，回退到系统 Python 后缺 cryptography
+    let hint = if detail.contains("No module named") {
+        "\n\n提示：Python 依赖缺失。请在应用实际使用的 Python 中执行 \
+         `python -m pip install cryptography pywin32` 后重启应用\
+         （应用使用的解释器见 app.log 中 python_exe= 一行）。"
+    } else {
+        ""
+    };
+    Err(format!("CA 证书生成失败：{detail}{hint}"))
+}
+
 #[tauri::command]
 pub fn cert_install(app: AppHandle, state: State<AppState>) -> Result<CertStatus, String> {
     // 1. 确保 CA 证书已生成（data_dir/certs/ca.cer）
     let cer = state.path("certs").join("ca.cer");
     if !cer.exists() {
-        let _ = spawn_script(&state, "device_proxy.py", &["--gen-ca".to_string()], false)?
-            .wait();
+        gen_ca(&state)?;
     }
     if !cer.exists() {
-        return Err("CA 证书生成失败，无法安装".into());
+        return Err("CA 证书生成失败：证书文件未生成（请查看日志）".into());
     }
     let cer_arg = cer.to_string_lossy().replace('\\', "/").to_string();
 
     // 2. 以管理员权限安装到本地计算机受信任根证书颁发机构（触发 UAC）
+    //    - 路径必须带引号：Start-Process 会把 -ArgumentList 各元素按空格拼成命令行，
+    //      用户名/数据目录含空格（如 C:/Users/John Doe/...）时会被拆成多个参数而失败。
+    //    - 用 -PassThru 拿到进程对象并 exit $p.ExitCode：仅 -Wait 只等待不取退出码，
+    //      certutil 执行失败时 PowerShell 仍返回 0，会误报「安装成功」。
     let ps = format!(
-        "Start-Process certutil -ArgumentList '-addstore','-f','Root','{}' -Verb RunAs -Wait",
-        cer_arg
+        "$p = Start-Process certutil -ArgumentList '-addstore','-f','Root','\"{cer_arg}\"' -Verb RunAs -PassThru -Wait; exit $p.ExitCode"
     );
     let status = Command::new("powershell")
         .args(["-NoProfile", "-Command", &ps])
@@ -51,8 +88,10 @@ pub fn cert_install(app: AppHandle, state: State<AppState>) -> Result<CertStatus
         .map_err(|e| format!("启动证书安装失败: {e}"))?;
 
     if !status.success() {
-        return Err("证书安装被取消或失败（可能需要管理员权限）".into());
+        return Err(format!(
+            "证书安装被取消或失败（可能需要管理员权限；certutil 退出码 {:?}）",
+            status.code()
+        ));
     }
-    let _ = app;
     Ok(cert_status(app, state))
 }

--- a/src/components/SetupGuide.tsx
+++ b/src/components/SetupGuide.tsx
@@ -23,6 +23,7 @@ export default function SetupGuide() {
   const startProxy = useAppStore((s) => s.startProxy);
   const refreshEnv = useAppStore((s) => s.refreshEnv);
   const refreshCert = useAppStore((s) => s.refreshCert);
+  const pushToast = useAppStore((s) => s.pushToast);
 
   const [busy, setBusy] = useState<string | null>(null);
 
@@ -99,8 +100,10 @@ export default function SetupGuide() {
     try {
       await step.run();
     } catch (e) {
-      // 错误已由各 step.run() 内部 toast 处理；此处兜底防止未捕获异常
+      // 并非每个 step.run() 内部都会 toast（如 cert 一步只抛错），
+      // 此处必须兜底提示，否则用户点击后界面毫无反应，无法定位失败原因。
       console.error(`[SetupGuide] step "${step.key}" failed:`, e);
+      pushToast('error', `「${step.title}」失败：${String(e)}`);
     } finally {
       setBusy(null);
     }

--- a/src/pages/doubao/DoubaoOverview.tsx
+++ b/src/pages/doubao/DoubaoOverview.tsx
@@ -93,6 +93,7 @@ function DoubaoSetupGuide({ installed, accounts }: { installed: boolean; account
       await step.run();
     } catch (e) {
       console.error(`[DoubaoSetupGuide] step "${step.key}" failed:`, e);
+      pushToast('error', `「${step.title}」失败：${String(e)}`);
     } finally {
       setBusy(null);
     }


### PR DESCRIPTION
Fixes #6, Fixes #7

## 背景

两个 issue 是同一台机器上依次暴露出来的，都已给出完整复现与日志证据：

- **#6**：点击「安装证书」毫无反应。根因是安装包未随附 Python 运行时与依赖，回退到系统 Python 后缺 `cryptography`，而失败信息在三层被吞掉。
- **#7**：代理显示「已启动」但目标域名全部打不开、日志不再新增。根因是泄漏的代理子进程仍在占用端口，且 `log()` 抛异常会掐断 CONNECT 握手。

本 PR 修复其中**代码层面**的问题（错误可见性、健壮性）；#6 的根因「安装包需随附 Python 运行时 + cryptography」属于打包/CI 改动，未包含在本 PR，建议在 CI 中单独处理。

## 改动清单

### `src-tauri/src/commands/cert.rs`

1. **新增 `gen_ca()`，捕获子进程的真实失败原因**（原实现 `let _ = ...wait()` 丢弃退出码、`capture=false` 不回收 stderr）
   - 取 stderr 末 5 行回传，替代原来那句无法定位的「CA 证书生成失败」
   - 对最常见的 `No module named` 追加可执行的修复提示（`pip install cryptography pywin32`），并说明如何从 app.log 的 `python_exe=` 一行确认应用使用的解释器
2. **PowerShell 路径加引号**：`Start-Process` 会把 `-ArgumentList` 各元素按空格拼成命令行，用户名/数据目录含空格时会被拆成多个参数而失败
3. **改用 `-PassThru` + `exit $p.ExitCode`**：原来只有 `-Wait`，certutil 执行失败时 PowerShell 仍返回 0，会误报「安装成功」

### `src/components/SetupGuide.tsx`、`src/pages/doubao/DoubaoOverview.tsx`

- 配置导航 `handleRun` 的 `catch` 补 `pushToast`。原来只 `console.error`，而 cert 这一步的 `run()` 内部并没有 toast（原注释是错的），导致后端 `Err` 被完全静默吞掉——这就是用户看到的「点了没反应」

### `src-python/device_proxy.py`

1. **`log()` 的 `print()` 也纳入容错**：父进程退出后本进程成为孤儿，stdout 管道断开会让 `print(..., flush=True)` 抛 `OSError`；而 `print` 原本在 `try` 之外，异常会直接杀死调用线程
2. **`handle_client` 目标域名分支改为先回 `200` 再记日志**，与 `tunnel_raw()` 保持一致。原来的顺序（先 `log` 后 `sendall`）下，任何日志异常都会让客户端永远等不到 `200`
3. **去掉 `SO_REUSEADDR` + `bind()` 失败时明确报错退出（退出码 2）**：Windows 上 `SO_REUSEADDR` 允许多个套接字绑定同一 `addr:port` 且不报错，是 #7「新代理假启动、旧进程继续接客」的直接诱因。去掉后端口被占用会立即暴露

## 验证

- ✅ 前端：`npx tsc --noEmit` 通过（0 错误）
- ✅ Python：`py_compile` 通过；并实测——在 8899 已被占用时启动，新实例输出
  `[fatal] 端口 127.0.0.1:8899 绑定失败（[WinError 10048] …）。通常由上一次未退出的代理进程占用，请结束后重试。`
  并以退出码 2 结束（不再是「假启动」）
- ✅ 端到端：结束泄漏进程后，原始 socket 探测返回 `HTTP/1.1 200 Connection Established`，`curl -x 127.0.0.1:8899 https://api.trae.cn/...` 返回 401、非目标域名返回 200，代理恢复正常
- ✅ Rust：`cargo check` 通过（`Finished dev profile`，0 error；`stable-x86_64-pc-windows-gnu`）
- ✅ 前端产物：`npm run build` 成功（vite build，含本次两处 TSX 改动）

## 建议后续（本 PR 未包含）

- 安装包随附精简 Python 运行时 + `cryptography`，或首次启动时自动 `pip install -r requirements.txt`
- 启动时按脚本路径清理遗留的 `device_proxy.py` 进程
- 应用退出时用 Job Object 确保子进程树被回收
- `proxy_start` 前主动探测端口占用，把本 PR 里 Python 侧的退出码 2 转成界面上的明确提示
